### PR TITLE
Fix for infinity in game data

### DIFF
--- a/src/helpers/loading.js
+++ b/src/helpers/loading.js
@@ -4,6 +4,7 @@ const returnPrefix = /^return /;
 const stringKeys = /\["(.*?)"\]=/g;
 const numberKeys = /\[(\d+)\]=/g;
 const trailingCommas = /,}/g;
+const infValue = /:inf/g;
 
 const numberKey = /"NOSTRING_(\d+)":/g
 const stringKey = /"([^"]*?)":/g;
@@ -21,7 +22,8 @@ function rawToJSON(data) {
     .replace(returnPrefix, "")
     .replace(stringKeys, "\"$1\":")
     .replace(numberKeys, "\"NOSTRING_$1\":")
-    .replace(trailingCommas, "}"));
+    .replace(trailingCommas, "}")
+    .replace(infValue, ":\"_INFINITY\""));
 }
 
 function FixJSONArrays (json) {
@@ -67,7 +69,8 @@ function FixLuaArrays (json) {
 function JSONToRaw(data) {
   return 'return ' + JSON.stringify(data)
     .replace(numberKey, "[$1]=")
-    .replace(stringKey, "[\"$1\"]=");
+    .replace(stringKey, "[\"$1\"]=")
+    .replaceAll(/\"_INFINITY\"/g, 'inf');
 };
 
 function processFile(buffer) {


### PR DESCRIPTION
Hey, thanks for making this tool, it's super helpful!

I encountered an issue trying to parse a saved game where naneinf had been scored. The `inf` value was causing an error in `JSON.parse`.

I added a check for it, replacing it with `"_INFINITY"` in the output. Hopefully that's unique enough to not cause any issues.

I tested parsing, saving, and opening the game in Balatro, and didn't have any trouble, but you may want to test a little more on your end.

Cheers!